### PR TITLE
lint all files with self-consuming config, create lint step in workflow

### DIFF
--- a/.github/workflows/main_branch_trigger.yml
+++ b/.github/workflows/main_branch_trigger.yml
@@ -1,4 +1,4 @@
-name: Main Branch Trigger
+name: Main Branch Checks
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  main_branch_job:
+  main_branch_checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Lint step
+        run: pnpm lint
 
       - name: Build step
         run: pnpm build

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # prettier-config
+
 Prettier config used at [monogram.io](https://monogram.io)
 
 ## Installing
@@ -6,6 +7,7 @@ Prettier config used at [monogram.io](https://monogram.io)
 ### Auto install
 
 Executing it with `npx` from the project's root will perform the manual installation steps, installing `@monogram/prettier-config` as a dev dependency and adding `"prettier": "@monogram/prettier-config"` to your project's `package.json`.
+
 ```sh
 npx @monogram/prettier-config
 ```
@@ -18,24 +20,23 @@ Install the package using your package manager
 yarn add -D @monogram/prettier-config
 # or
 npm i -D @monogram/prettier-config
-# or 
+# or
 pnpm i -D @monogram/prettier-config
 ```
-
 
 Add the `prettier` key to your `package.json`
 
 ```diff
 +++  "prettier": "@monogram/prettier-config"
- ```
+```
 
 ## Extending
 
- Can also be extended like this:
- 
- ```js
- // .prettierrc.js
- module.exports = {
+Can also be extended like this:
+
+```js
+// .prettierrc.js
+module.exports = {
   ...require('@monogram/prettier-config'),
   tabWidth: 2,
   useTabs: false,
@@ -46,15 +47,15 @@ Add the `prettier` key to your `package.json`
         singleQuote: true,
         tabWidth: 2,
         useTabs: false,
-        printWidth: 160
-      }
-    }
-  ]
+        printWidth: 160,
+      },
+    },
+  ],
 }
- ```
+```
 
- [Check out the `prettier` documentation for more info on sharing configurations](https://prettier.io/docs/en/configuration.html#sharing-configurations).
-
+[Check out the `prettier` documentation for more info on sharing configurations](https://prettier.io/docs/en/configuration.html#sharing-configurations).
 
 ## Acknowledgment
- Inspired by [@github/prettier-config](https://www.npmjs.com/package/@github/prettier-config).
+
+Inspired by [@github/prettier-config](https://www.npmjs.com/package/@github/prettier-config).

--- a/npmjs.md
+++ b/npmjs.md
@@ -1,5 +1,7 @@
 ### Push to npmjs.com
+
 ```sh
 npm publish --access public
 ```
+
 Read more on npmjs.com [Publishing scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preinstall-locally": "yarn build",
     "install-locally": "npm install -g",
     "build": "rm -rf dist ; tsc",
-    "prepublish": "yarn build"
+    "prepublish": "yarn build",
+    "lint": "prettier --check \"**/*.{js,ts,md}\""
   },
   "bin": "dist/setup.js",
   "files": [
@@ -28,5 +29,6 @@
     "@types/node": "^17.0.23",
     "prettier": "^3.0.1",
     "typescript": "^4.6.2"
-  }
+  },
+  "prettier": "./prettierrc.config.js"
 }

--- a/prettierrc.config.js
+++ b/prettierrc.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   printWidth: 100,
   singleQuote: true,
-  trailingComma: "es5",
+  trailingComma: 'es5',
   semi: false,
-  plugins: ["prettier-plugin-tailwindcss"],
-};
+  plugins: ['prettier-plugin-tailwindcss'],
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,21 +1,21 @@
-import type { PackageManagerRecord } from "./types";
+import type { PackageManagerRecord } from './types'
 
-export const PACKAGE_NAME = "@monogram/prettier-config";
+export const PACKAGE_NAME = '@monogram/prettier-config'
 
-export const ESLINT_FILENAME = ".eslintrc.js";
+export const ESLINT_FILENAME = '.eslintrc.js'
 
-export const AVAILABLE_CONFIGS = ["next", "node"] as const;
+export const AVAILABLE_CONFIGS = ['next', 'node'] as const
 
-export const PACKAGE_MANAGERS = ["yarn", "pnpm", "npm"] as const;
+export const PACKAGE_MANAGERS = ['yarn', 'pnpm', 'npm'] as const
 
 export const LOCK_FILES: PackageManagerRecord = {
   yarn: `${process.cwd()}/yarn.lock`,
   pnpm: `${process.cwd()}/pnpm-lock.yaml`,
   npm: `${process.cwd()}/package-lock.json`,
-} as const;
+} as const
 
 export const INSTALL_PREFIXES: PackageManagerRecord = {
-  yarn: "yarn add -D",
-  pnpm: "pnpm add -D",
-  npm: "npm i -D",
-} as const;
+  yarn: 'yarn add -D',
+  pnpm: 'pnpm add -D',
+  npm: 'npm i -D',
+} as const

--- a/src/package-managers.ts
+++ b/src/package-managers.ts
@@ -1,38 +1,36 @@
-import { existsSync } from "node:fs";
-import { select, confirm } from "@inquirer/prompts";
-import { LOCK_FILES, PACKAGE_MANAGERS } from "./constants";
-import type { PackageManager } from "./types";
+import { existsSync } from 'node:fs'
+import { select, confirm } from '@inquirer/prompts'
+import { LOCK_FILES, PACKAGE_MANAGERS } from './constants'
+import type { PackageManager } from './types'
 
 export async function choosePackageManager(): Promise<PackageManager> {
-  const packageManager = findPackageManager();
+  const packageManager = findPackageManager()
 
   if (packageManager === undefined) {
-    return selectPackageManager();
+    return selectPackageManager()
   }
 
   const useAutoDetected = await confirm({
     message: `Auto-detected package manager. Use ${packageManager} for installation?`,
     default: true,
-  });
+  })
 
   if (useAutoDetected === false) {
-    return selectPackageManager();
+    return selectPackageManager()
   }
 
-  return packageManager;
+  return packageManager
 }
 
 function findPackageManager(): PackageManager | undefined {
-  return PACKAGE_MANAGERS.find((packageManager) =>
-    existsSync(LOCK_FILES[packageManager])
-  );
+  return PACKAGE_MANAGERS.find((packageManager) => existsSync(LOCK_FILES[packageManager]))
 }
 
 function selectPackageManager() {
   return select({
-    message: "Which package manager should be used for installation?",
+    message: 'Which package manager should be used for installation?',
     choices: PACKAGE_MANAGERS.map((packageManager) => ({
       value: packageManager,
     })),
-  });
+  })
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,38 +11,38 @@ import { confirm } from '@inquirer/prompts'
 init().catch(console.error)
 
 async function init() {
-	const projectDir = process.cwd()
-	const packagePath = `${projectDir}/package.json`
+  const projectDir = process.cwd()
+  const packagePath = `${projectDir}/package.json`
 
-	if (!existsSync(packagePath)) {
-		throw Error(`Can't find package.json in ${projectDir}`)
-	}
+  if (!existsSync(packagePath)) {
+    throw Error(`Can't find package.json in ${projectDir}`)
+  }
 
-	const packageJson = require(packagePath)
+  const packageJson = require(packagePath)
 
-	if (packageJson.prettier) {
-		const yes = await confirm({
-			message: `'prettier' key (${packageJson.prettier}) found in package.json. Do you want to replace it?`
-		})
+  if (packageJson.prettier) {
+    const yes = await confirm({
+      message: `'prettier' key (${packageJson.prettier}) found in package.json. Do you want to replace it?`,
+    })
 
-		if (yes === false) throw Error('Aborted')
-	}
+    if (yes === false) throw Error('Aborted')
+  }
 
-	packageJson.prettier = PACKAGE_NAME
+  packageJson.prettier = PACKAGE_NAME
 
-	const packageJsonString = JSON.stringify(packageJson, null, 2)
+  const packageJsonString = JSON.stringify(packageJson, null, 2)
 
-	const packageManager = await choosePackageManager()
-	await installDependencies(packageManager)
+  const packageManager = await choosePackageManager()
+  await installDependencies(packageManager)
 
-	await writeFile(packagePath, packageJsonString)
+  await writeFile(packagePath, packageJsonString)
 }
 
 async function installDependencies(packageManager: PackageManager) {
-	const installPrefix = INSTALL_PREFIXES[packageManager]
-	const installCommand = `${installPrefix} prettier ${PACKAGE_NAME}`
+  const installPrefix = INSTALL_PREFIXES[packageManager]
+  const installCommand = `${installPrefix} prettier ${PACKAGE_NAME}`
 
-	console.log(`📦 Installing dependencies...`)
-	console.log(`👉 ${installCommand}`)
-	execSync(installCommand, { stdio: 'inherit' })
+  console.log(`📦 Installing dependencies...`)
+  console.log(`👉 ${installCommand}`)
+  execSync(installCommand, { stdio: 'inherit' })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import type { AVAILABLE_CONFIGS, PACKAGE_MANAGERS } from "./constants";
+import type { AVAILABLE_CONFIGS, PACKAGE_MANAGERS } from './constants'
 
-export type AvailableConfig = (typeof AVAILABLE_CONFIGS)[number];
-export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+export type AvailableConfig = (typeof AVAILABLE_CONFIGS)[number]
+export type PackageManager = (typeof PACKAGE_MANAGERS)[number]
 
-export type PackageManagerRecord = Record<PackageManager, string>;
+export type PackageManagerRecord = Record<PackageManager, string>


### PR DESCRIPTION
It looks like a lot of changes, but the files weren't being linted before. Now it's using the prettier-config to lint the project itself.

changes:
- format all files
- add lint checker step in workflow
- add "prettier" value and `lint` script in `package.json`